### PR TITLE
Fix the gem when used with jQuery >= 1.9

### DIFF
--- a/app/assets/javascripts/active_admin/active_admin_globalize3.js.coffee
+++ b/app/assets/javascripts/active_admin/active_admin_globalize3.js.coffee
@@ -19,7 +19,7 @@ $ ->
         $tabs.eq(0).click()
 
   # this is to handle elements created with has_many
-  $("a").live "click", ->
+  $("a").on "click", ->
     setTimeout(
       -> translations()
       50


### PR DESCRIPTION
Please take a look at the attached commit. Per http://api.jquery.com/live/ .live has been deprecated / removed. The commit replaces it with .on, which is available since v1.7.: http://api.jquery.com/on/ .
