### PR TITLE
Fix 'pt' locale key and add translations for pt-BR and pt-PT

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,3 +8,4 @@ en:
         es: "Spanish"
         de: "German"
         pt-BR: "Portuguese"
+        pt-PT: "Portuguese (Portugal)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,4 +7,4 @@ en:
         en: "English"
         es: "Spanish"
         de: "German"
-        pt: "Portuguese"
+        pt-BR: "Portuguese"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -7,4 +7,4 @@ it:
         en: "Inglese"
         es: "Spagnolo"
         de: "Tedesco"
-        pt: "Portoghese"
+        pt-BR: "Portoghese"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -8,3 +8,4 @@ it:
         es: "Spagnolo"
         de: "Tedesco"
         pt-BR: "Portoghese"
+        pt-PT: "Portoghese (Portogallo)"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,11 @@
+pt-BR:
+ active_admin:
+    globalize3:
+      translations: "Traduções"
+      language:
+        it: "Italiano"
+        en: "Inglês"
+        es: "Espanhol"
+        de: "Alemão"
+        pt-BR: "Português"
+        pt-PT: "Português (Portugal)"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -1,0 +1,11 @@
+pt-PT:
+ active_admin:
+    globalize3:
+      translations: "Traduções"
+      language:
+        it: "Italiano"
+        en: "Inglês"
+        es: "Espanhol"
+        de: "Alemão"
+        pt-BR: "Português"
+        pt-PT: "Português (Portugal)"


### PR DESCRIPTION
Hello,

FYI, the default locale is 'pt-BR', not just 'pt'. You can check the full list on [rails-i18n repository](https://github.com/svenfuchs/rails-i18n#available-locales).

This pull request:
-  changes 'pt' key to 'pt-BR', the default portuguese locale key
-  adds pt-PT key for portuguese from Portugal
-  adds locale files for both pt-BR and pt-PT

Regards
