### PR TITLE
Add options auto_sort to form_builder_extension "translated_inputs"

### DIFF
--- a/lib/active_admin/globalize3/form_builder_extension.rb
+++ b/lib/active_admin/globalize3/form_builder_extension.rb
@@ -16,7 +16,7 @@ module ActiveAdmin
               end
             end.join.html_safe
           end <<
-          I18n.available_locales.sort.map do |locale|
+          I18n.available_locales.map do |locale|
             translation = object.translations.find { |t| t.locale.to_s == locale.to_s }
             translation ||= object.translations.build(locale: locale)
             fields = proc do |form|

--- a/lib/active_admin/globalize3/form_builder_extension.rb
+++ b/lib/active_admin/globalize3/form_builder_extension.rb
@@ -6,9 +6,11 @@ module ActiveAdmin
       def translated_inputs(name = "Translations", options = {}, &block)
         options.symbolize_keys!
         switch_locale = options.fetch(:switch_locale, false)
+        auto_sort = options.fetch(:auto_sort, :false)
         form_buffers.last << template.content_tag(:div, class: "activeadmin-translations") do
           template.content_tag(:ul, class: "available-locales") do
-            I18n.available_locales.map do |locale|
+            locales = auto_sort ? I18n.available_locales.sort : I18n.available_locales
+            locales.map do |locale|
               template.content_tag(:li) do
                 I18n.with_locale(switch_locale ? locale : I18n.locale) do
                   template.content_tag(:a, I18n.t(:"active_admin.globalize3.language.#{locale}"), href:".locale-#{locale}")

--- a/lib/active_admin/globalize3/form_builder_extension.rb
+++ b/lib/active_admin/globalize3/form_builder_extension.rb
@@ -17,7 +17,7 @@ module ActiveAdmin
               end
             end.join.html_safe
           end <<
-          I18n.available_locales.map do |locale|
+          (auto_sort ? I18n.available_locales.sort : I18n.available_locales).map do |locale|
             translation = object.translations.find { |t| t.locale.to_s == locale.to_s }
             translation ||= object.translations.build(locale: locale)
             fields = proc do |form|

--- a/lib/active_admin/globalize3/form_builder_extension.rb
+++ b/lib/active_admin/globalize3/form_builder_extension.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
       def translated_inputs(name = "Translations", options = {}, &block)
         options.symbolize_keys!
         switch_locale = options.fetch(:switch_locale, false)
-        auto_sort = options.fetch(:auto_sort, :false)
+        auto_sort = options.fetch(:auto_sort, true)
         form_buffers.last << template.content_tag(:div, class: "activeadmin-translations") do
           template.content_tag(:ul, class: "available-locales") do
             (auto_sort ? I18n.available_locales.sort : I18n.available_locales).map do |locale|

--- a/lib/active_admin/globalize3/form_builder_extension.rb
+++ b/lib/active_admin/globalize3/form_builder_extension.rb
@@ -9,8 +9,7 @@ module ActiveAdmin
         auto_sort = options.fetch(:auto_sort, :false)
         form_buffers.last << template.content_tag(:div, class: "activeadmin-translations") do
           template.content_tag(:ul, class: "available-locales") do
-            locales = auto_sort ? I18n.available_locales.sort : I18n.available_locales
-            locales.map do |locale|
+            (auto_sort ? I18n.available_locales.sort : I18n.available_locales).map do |locale|
               template.content_tag(:li) do
                 I18n.with_locale(switch_locale ? locale : I18n.locale) do
                   template.content_tag(:a, I18n.t(:"active_admin.globalize3.language.#{locale}"), href:".locale-#{locale}")


### PR DESCRIPTION
Adds an option auto_sort, so that it is possible to sort the language tabs manually by entering the locales in a specific way into I18n.avaliable_locales. Sometimes the default language must not be the first in the alphabet.

default: 
auto_sort => true

``` ruby
# Acts like it does now
# I18n.available_locals = [:en, :de]
# German comes before English, cause its sorted alphabedically by locale-code
f.translated_inputs "Translated fields" do |t|
 ...
end

# Locales are sort bei the order of the entries
# I18n.available_locals = [:en, :de]
# Englisch tab is rendered before German
f.translated_inputs "Translated fields", auto_sort: false do |t|
 ...
end
```
