### PR TITLE
Avoid saving new translations that are empty, remove existing empty translations. 

### DIFF
--- a/lib/active_admin/globalize3/engine.rb
+++ b/lib/active_admin/globalize3/engine.rb
@@ -1,3 +1,5 @@
+require 'active_admin/globalize3/filter_empty_translations'
+
 module ActiveAdmin
   module Globalize3
     class Engine < ::Rails::Engine
@@ -11,6 +13,14 @@ module ActiveAdmin
       initializer "add assets" do
         ActiveAdmin.application.register_stylesheet "active_admin/active_admin_globalize3.css", :media => :screen
         ActiveAdmin.application.register_javascript "active_admin/active_admin_globalize3.js"
+      end
+
+      # Register a before_filter in ActionController that will filter out
+      # empty translations submitted by activeadmin-globalize3.
+      # See ActiveAdmin::Globalize3::FilterEmptyTranslations#filter_empty_translations
+      initializer "activeadmin-globalize3.load_helpers" do |app|
+        ActionController::Base.send :include, ActiveAdmin::Globalize3::FilterEmptyTranslations
+        ActionController::Base.send :before_filter, :filter_empty_translations, only: [:create, :update]
       end
 
     end

--- a/lib/active_admin/globalize3/filter_empty_translations.rb
+++ b/lib/active_admin/globalize3/filter_empty_translations.rb
@@ -1,0 +1,48 @@
+module ActiveAdmin
+  module Globalize3
+    module FilterEmptyTranslations
+      private
+      # Activeadmin-globalize3 renders inputs for all translations,
+      # resulting in many empty translations being created by globalize.
+      #
+      # For instance, given the available locales L1, L2 and L2, the
+      # following params would be submitted on 'create':
+      #
+      # {
+      #   :
+      #   MODEL => {
+      #     "translations_attributes" => {
+      #       "0" => {
+      #         "locale"=>"L1", "id" => "", ATTR1 => "", ATTR2 => "", ...
+      #       }
+      #       "1" => {
+      #         "locale"=>"L2", "id" => "", ATTR1 => "", ATTR2 => "", ...
+      #       }
+      #       "2" => {
+      #         "locale"=>"L3", "id" => "", ATTR1 => "", ATTR2 => "", ...
+      #       }
+      #     }
+      #   }
+      #   :
+      # }
+      #
+      # Given these parameters, globalize3 would create a record for every
+      # possible translation - even empty ones.
+      #
+      # This filter removes all empty and unsaved translations from params
+      # and marks empty and saved translation for deletion.
+      def filter_empty_translations
+        model = controller_name.singularize.to_sym
+        params[model][:translations_attributes].each do |t|
+          if !(t.last.map { |_, v| v.empty? ? true : false }[2..-1]).include?(false)
+            if t.last[:id].empty?
+              params[model][:translations_attributes].delete(t.first)
+            else
+              params[model][:translations_attributes][t.first]['_destroy'] = '1'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/globalize3/filter_empty_translations.rb
+++ b/lib/active_admin/globalize3/filter_empty_translations.rb
@@ -32,7 +32,11 @@ module ActiveAdmin
       # This filter removes all empty and unsaved translations from params
       # and marks empty and saved translation for deletion.
       def filter_empty_translations
-        model = controller_name.singularize.to_sym
+        model_class = controller_name.classify.safe_constantize
+        if model_class.nil? or not model_class.translates?
+          return
+        end
+        model = controller_name.singularize.to_sym        
         params[model][:translations_attributes].each do |t|
           if !(t.last.map { |_, v| v.empty? ? true : false }[2..-1]).include?(false)
             if t.last[:id].empty?

--- a/lib/active_admin/globalize3/filter_empty_translations.rb
+++ b/lib/active_admin/globalize3/filter_empty_translations.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 module ActiveAdmin
   module Globalize3
     module FilterEmptyTranslations
@@ -36,13 +37,13 @@ module ActiveAdmin
         if model_class.nil? or not model_class.translates?
           return
         end
-        model = controller_name.singularize.to_sym        
-        params[model][:translations_attributes].each do |t|
-          if !(t.last.map { |_, v| v.empty? ? true : false }[2..-1]).include?(false)
-            if t.last[:id].empty?
-              params[model][:translations_attributes].delete(t.first)
+        model = controller_name.singularize.to_sym
+        params[model][:translations_attributes].each do |k,v|
+          if v.values[2..-1].all?(&:blank?)
+            if v[:id].empty?
+              params[model][:translations_attributes].delete(k)
             else
-              params[model][:translations_attributes][t.first]['_destroy'] = '1'
+              params[model][:translations_attributes][k]['_destroy'] = '1'
             end
           end
         end


### PR DESCRIPTION
Activeadmin-globalize3 renders inputs for all possible translations. Consequently, `params` will contain translations for all attributes - even empty ones - and many empty translation records will be created.

This feature registers a `before_filter` in `ActionController::Base` that will
1. remove new and empty translations from `params` before creating any empty records
2. mark existing and empty translations in `params` for deletion

See https://github.com/stefanoverna/activeadmin-globalize3/issues/10, most credits go to [codingluke](https://github.com/codingluke) and [fabn](https://github.com/fabn), thanks!
