### PR TITLE
Don't use attr_accessible if we're using strong parameters

### DIFF
--- a/lib/active_admin/globalize3/active_record_extension.rb
+++ b/lib/active_admin/globalize3/active_record_extension.rb
@@ -16,10 +16,13 @@ module ActiveAdmin::Globalize3
       if block
         translation_class.instance_eval &block
       end
-      translation_class.attr_accessible :locale
-      translation_class.attr_accessible *args
 
-      attr_accessible :translations_attributes
+      unless translation_class.ancestors.include? ::ActiveModel::ForbiddenAttributesProtection
+        translation_class.attr_accessible :locale
+        translation_class.attr_accessible *args
+      end
+
+      attr_accessible :translations_attributes unless ancestors.include? ::ActiveModel::ForbiddenAttributesProtection
       accepts_nested_attributes_for :translations, allow_destroy: true
 
       include Methods
@@ -27,4 +30,3 @@ module ActiveAdmin::Globalize3
 
   end
 end
-


### PR DESCRIPTION
... otherwise, only `translations_attributes` would get assigned leaving out the rest.
