### PR TITLE
Map ancestors to strings before checking for ForbiddenAttributesProtection class

### DIFF
--- a/lib/active_admin/globalize3/active_record_extension.rb
+++ b/lib/active_admin/globalize3/active_record_extension.rb
@@ -17,12 +17,12 @@ module ActiveAdmin::Globalize3
         translation_class.instance_eval &block
       end
 
-      unless translation_class.ancestors.include? ::ActiveModel::ForbiddenAttributesProtection
+      unless translation_class.ancestors.map(&:to_s).include?('ActiveModel::ForbiddenAttributesProtection')
         translation_class.attr_accessible :locale
         translation_class.attr_accessible *args
       end
 
-      attr_accessible :translations_attributes unless ancestors.include? ::ActiveModel::ForbiddenAttributesProtection
+      attr_accessible :translations_attributes unless ancestors.map(&:to_s).include?('ActiveModel::ForbiddenAttributesProtection')
       accepts_nested_attributes_for :translations, allow_destroy: true
 
       include Methods


### PR DESCRIPTION
Following-up on PR #16, if strong_parameters isn't installed, this would raise `uninitialized constant ActiveModel::ForbiddenAttributesProtection`.

It may looks hack-ish to map ancestors to strings, but solves the problem, otherwise if/unless condition statements would look a bit ugly and redundant. I could've refactored it into couple of methods but I didn't want to pollute the model classes.
