### PR TITLE
Select locales manually and avoid saving empty translations

### DIFF
--- a/app/assets/javascripts/active_admin/active_admin_globalize.js.coffee
+++ b/app/assets/javascripts/active_admin/active_admin_globalize.js.coffee
@@ -2,6 +2,30 @@ $ ->
 
   translations = ->
 
+    # Hides or shows the + button and the remove button.
+    updateLocaleButtonsStatus = ($dom) ->
+      $localeList = $dom.find('.add-locale ul li:not(.hidden)')
+      if ($localeList.length == 0)
+        $dom.find('.add-locale').hide()
+      else
+        $dom.find('.add-locale').show()
+
+      $tabs = $dom.children('li:not(.add-locale)').find('a:not(.hidden)')
+      if ($tabs.length > 1)
+        $tabs.find('span').removeClass('hidden')
+      else
+        $tabs.find('span').addClass('hidden')
+
+    # Hides or shows the locale tab and its corresponding element in the add menu.
+    toggleTab = ($tab, active) ->
+      $addButton = $tab.parents('ul').find('.add-locale li:has(a[href="' + $tab.attr('href') + '"])')
+      if active
+        $tab.addClass('hidden').show().removeClass('hidden')
+        $addButton.hide().addClass('hidden')
+      else
+        $tab.addClass('hidden').hide().addClass('hidden')
+        $addButton.show().removeClass('hidden')
+
     $(".activeadmin-translations > ul").each ->
       $dom = $(this)
       if !$dom.data("ready")
@@ -9,21 +33,89 @@ $ ->
         $tabs = $("li > a", this)
         $contents = $(this).siblings("fieldset")
 
-        $tabs.click ->
+        $tabs.click (e) ->
           $tab = $(this)
           $tabs.not($tab).removeClass("active")
           $tab.addClass("active")
           $contents.hide()
           $contents.filter($tab.attr("href")).show()
-          false
+          e.preventDefault()
 
         $tabs.eq(0).click()
 
+        # Collect tha available locales.
+        availableLocales = []
+        $tabs.each ->
+          availableLocales.push($('<li></li>').append($(this).clone().removeClass('active')))
+
+        # Create a new tab as the root of the drop down menu.
+        $addLocaleButton = $('<li class="add-locale"><a href="#">+</a></li>')
+        $addLocaleButton.append($('<ul></ul>').append(availableLocales))
+
+        # Handle locale addition
+        $addLocaleButton.find('ul a').click (e) ->
+          href = $(this).attr('href')
+          $tab = $tabs.filter('[href="' + href + '"]')
+          toggleTab($tab, true)
+          $tab.click()
+          updateLocaleButtonsStatus($dom)
+          e.preventDefault()
+
+        # Remove a locale from the tab.
+        $removeButton = $('<span class="remove">x</span>').click (e) ->
+          e.stopImmediatePropagation()
+          e.preventDefault()
+          $tab = $(this).parent()
+          toggleTab($tab, false)
+          if $tab.hasClass('active')
+            $tabs.not('.hidden').eq(0).click()
+
+          updateLocaleButtonsStatus($dom)
+
+        # Add the remove button to every tab.
+        $tabs.append($removeButton)
+
+        # Add the new button at the end of the locale list.
+        $dom.append($addLocaleButton)
+
+        numberOfHidden = 0
         $tabs.each ->
           $tab = $(@)
           $content = $contents.filter($tab.attr("href"))
           containsErrors = $content.find(".input.error").length > 0
           $tab.toggleClass("error", containsErrors)
+          # Find those tabs that are in use.
+          hide = true
+          # We will not hide the tabs that have any error.
+          if $tab.hasClass('error')
+            hide = false
+          else
+            # Check whether the input fields are empty or not.
+            $content.find('[name]').not('[type="hidden"]').each ->
+              if $(this).val()
+                # We will not hide the tab because it has some data.
+                hide = false
+                return false
+
+          if hide
+            numberOfHidden++
+            toggleTab($tab, false)
+          else
+            toggleTab($tab, true)
+
+        # Every tab became hidden, show the first one.
+        if numberOfHidden == $tabs.length
+          $tabs.eq(0).show().removeClass('hidden')
+          $addLocaleButton.find('li:has(a[href="' + $tabs.eq(0).attr('href') + '"])').hide().addClass('hidden')
+
+        # Remove the fields of those locales before form submission that have not been added.
+        $dom.parents('form').submit ->
+          $tabs.each ->
+            if $(this).hasClass('hidden')
+              $($(this).attr('href')).remove()
+
+        #Initially update the buttons' status
+        updateLocaleButtonsStatus($dom)
 
   # this is to handle elements created with has_many
   $("a").bind "click", ->

--- a/app/assets/stylesheets/active_admin/active_admin_globalize.css.sass
+++ b/app/assets/stylesheets/active_admin/active_admin_globalize.css.sass
@@ -55,6 +55,8 @@
 
       &> li.add-locale
         font-weight: bold
+        position: relative
+        z-index: 100
 
         &> ul
           display: none
@@ -65,6 +67,7 @@
           position: absolute
           +shadow(3px, 3px, 5px, #aaa)
           background: #f4f4f4
+          z-index: 100
 
           &> li
             font-size: 17px

--- a/app/assets/stylesheets/active_admin/active_admin_globalize.css.sass
+++ b/app/assets/stylesheets/active_admin/active_admin_globalize.css.sass
@@ -21,6 +21,7 @@
           padding: 8px 15px
           padding-bottom: 8px + 4px
           margin-bottom: 0
+          position: relative
 
           &.error
             color: #932419
@@ -33,6 +34,69 @@
             +gradient($secondary-gradient-stop, #f4f4f4)
             text-shadow: 0 1px 0 white
             color: #666 !important
+
+          &> span
+            font-size: 0.75em
+            font-weight: bold
+            position: absolute
+            top: 2px
+            right: 4px
+            display: none
+
+            &:hover
+              +text-shadow(red, 1px, 1px, 2px)
+
+          &:hover
+            span
+              display: block
+
+            span.hidden
+              display: none
+
+      &> li.add-locale
+        font-weight: bold
+
+        &> ul
+          display: none
+          font-size: 17px
+          font-weight: normal
+          padding: 0
+          +border-bottom-radius(4px)
+          position: absolute
+          +shadow(3px, 3px, 5px, #aaa)
+          background: #f4f4f4
+
+          &> li
+            font-size: 17px
+            padding: 8px 15px
+            padding-bottom: 8px + 4px
+            margin-bottom: 0
+
+            &:hover
+              background: #ddd
+              background: -webkit-linear-gradient(left, $secondary-gradient-stop, #f4f4f4)
+              background: -moz-linear-gradient(left, $secondary-gradient-stop, #f4f4f4)
+              background: linear-gradient(left, $secondary-gradient-stop, #f4f4f4)
+
+            &> a
+              text-decoration: none
+              color: #666
+
+          &> li:first-child
+            border-top-right-radius: 4px
+
+        &:hover
+          background: #f4f4f4
+          +inset-shadow(0, 4px, 4px, #ddd)
+          +border-top-radius(4px)
+          margin-bottom: 0
+          +gradient($secondary-gradient-stop, #f4f4f4)
+          text-shadow: 0 1px 0 white
+          color: #666 !important
+
+          &> ul
+            display: block
+
 
     &> fieldset.inputs
       margin-bottom: 0

--- a/lib/active_admin/globalize/engine.rb
+++ b/lib/active_admin/globalize/engine.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   module Globalize
     class Engine < ::Rails::Engine
-      initializer "Active Admin precompile hook", group: :assets do |app|
+      initializer "Active Admin precompile hook", group: :all do |app|
         app.config.assets.precompile += [
           "active_admin/active_admin_globalize.css",
           "active_admin/active_admin_globalize.js"

--- a/lib/active_admin/globalize/form_builder_extension.rb
+++ b/lib/active_admin/globalize/form_builder_extension.rb
@@ -10,9 +10,10 @@ module ActiveAdmin
         form_buffers.last << template.content_tag(:div, class: "activeadmin-translations") do
           template.content_tag(:ul, class: "available-locales") do
             (auto_sort ? I18n.available_locales.sort : I18n.available_locales).map do |locale|
+              default = 'default' if locale == I18n.default_locale
               template.content_tag(:li) do
                 I18n.with_locale(switch_locale ? locale : I18n.locale) do
-                  template.content_tag(:a, I18n.t(:"active_admin.globalize.language.#{locale}"), href:".locale-#{locale}")
+                  template.content_tag(:a, I18n.t(:"active_admin.globalize.language.#{locale}"), href:".locale-#{locale}", :class => default)
                 end
               end
             end.join.html_safe


### PR DESCRIPTION
This feature adds the capability of selecting locales manually to the locales tab. Users can select which locales they want to fill out in the form. The locales that have not been selected will not be saved as empty translations. The selected locales can be removed, except the default locale.

Add a locale:
![add](https://f.cloud.github.com/assets/149311/1995761/def371c0-8509-11e3-915a-46552af8babe.png)
Remove a locale:
![remove](https://f.cloud.github.com/assets/149311/1995765/e7ba283a-8509-11e3-831e-975de16eddaa.png)

The implementation is Javascript based, I extended only the form builder to add a class to the link of the default locale. 
