### PR TITLE
Get the latest translation instead of the first one ever saved

### DIFF
--- a/lib/active_admin/globalize/form_builder_extension.rb
+++ b/lib/active_admin/globalize/form_builder_extension.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
             end.join.html_safe
           end <<
           (auto_sort ? I18n.available_locales.sort : I18n.available_locales).map do |locale|
-            translation = object.translations.find { |t| t.locale.to_s == locale.to_s }
+            translation = object.translations.order(created_at: :desc).find { |t| t.locale.to_s == locale.to_s }
             translation ||= object.translations.build(locale: locale)
             fields = proc do |form|
               form.input(:locale, as: :hidden)


### PR DESCRIPTION
Sort all translations by created_at desc, to get the latest translation for the form, instead of the first one ever (default sorting). Works well with Active Admin commit fdc6a3d9faee98b4df21.
