### PR TITLE
Adapt README to AA-Reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ index do
   # ...
   translation_status
   # ...
-  default_actions
+  actions
 end
 
 form do |f|


### PR DESCRIPTION
`default_actions` is no longer provided in ActiveAdmin 1.x. Use `actions` instead.
